### PR TITLE
Add kodi-header component

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,5 +10,8 @@
   <kodi-app></kodi-app>
   <script type="module" src="js/lib/lit.min.js"></script>
   <script type="module" src="js/components/kodi-app.js"></script>
-  <script type="module" src="js/components/kodi-aside.js"></script>`n</body>
+  <script type="module" src="js/components/kodi-aside.js"></script>
+  <script type="module" src="js/components/kodi-header.js"></script>
+</body>
 </html>
+

--- a/js/components/kodi-header.js
+++ b/js/components/kodi-header.js
@@ -1,0 +1,16 @@
+import { LitElement, html, css } from '../lib/lit.min.js';
+
+class KodiHeader extends LitElement {
+  static styles = css`
+    header {
+      background: #333;
+      color: white;
+      padding: 10px;
+      text-align: center;
+    }
+  `;
+  render() {
+    return html`<header>Kodi Remote Control</header>`;
+  }
+}
+customElements.define('kodi-header', KodiHeader);


### PR DESCRIPTION
- Añadido componente `<kodi-header>` con Lit.
- Estilos básicos para el header (background: #333, color: white, padding: 10px).
- Actualizado index.html para incluir kodi-header.js.
- Pruebas: `npm start` muestra "Kodi Remote Control" en el header y "Sidebar content" en el aside sin errores.