### PR TITLE
Add kodi-main component and update kodi-app styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
   <script type="module" src="js/components/kodi-app.js"></script>
   <script type="module" src="js/components/kodi-aside.js"></script>
   <script type="module" src="js/components/kodi-header.js"></script>
+  <script type="module" src="js/components/kodi-main.js"></script>
 </body>
 </html>
+
 

--- a/js/components/kodi-app.js
+++ b/js/components/kodi-app.js
@@ -2,9 +2,22 @@ import { LitElement, html, css } from '../lib/lit.min.js';
 
 class KodiApp extends LitElement {
   static styles = css`
-    @import url('../../css/style.css');
-    :host { display: block; }
-    .container { display: flex; }
+    :host {
+      display: block;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    .container {
+      display: flex;
+      flex: 1;
+    }
+    kodi-aside {
+      flex: 0 0 200px; /* Fija el ancho del sidebar */
+    }
+    kodi-main {
+      flex: 1; /* Ocupa el resto del espacio */
+    }
   `;
   render() {
     return html`

--- a/js/components/kodi-main.js
+++ b/js/components/kodi-main.js
@@ -1,0 +1,15 @@
+import { LitElement, html, css } from '../lib/lit.min.js';
+
+class KodiMain extends LitElement {
+  static styles = css`
+    main {
+      flex: 1;
+      padding: 20px;
+      background: #fff;
+    }
+  `;
+  render() {
+    return html`<main>Main content area</main>`;
+  }
+}
+customElements.define('kodi-main', KodiMain);


### PR DESCRIPTION
- Añadido componente `<kodi-main>` con Lit.
- Estilos básicos para el área principal (flex: 1, padding: 20px, background: #fff).
- Actualizado kodi-app.js con estilos para layout (header arriba, sidebar izquierda, main derecha).
- Actualizado index.html para incluir kodi-main.js.
- Pruebas: `npm start` muestra header ("Kodi Remote Control"), sidebar ("Sidebar content"), y main ("Main content area") sin errores.