### PR TITLE
Add navigation menu to kodi-aside component

### DIFF
--- a/js/components/kodi-aside.js
+++ b/js/components/kodi-aside.js
@@ -2,10 +2,40 @@ import { LitElement, html, css } from '../lib/lit.min.js';
 
 class KodiAside extends LitElement {
   static styles = css`
-    aside { width: 200px; background: #f0f0f0; }
+    aside {
+      width: 200px;
+      background: #f0f0f0;
+      padding: 10px;
+      box-sizing: border-box;
+    }
+    nav {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    button {
+      padding: 10px;
+      background: #007bff;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 16px;
+    }
+    button:hover {
+      background: #0056b3;
+    }
   `;
   render() {
-    return html`<aside>Sidebar content</aside>`;
+    return html`
+      <aside>
+        <nav>
+          <button>Play</button>
+          <button>Stop</button>
+          <button>Menu</button>
+        </nav>
+      </aside>
+    `;
   }
 }
 customElements.define('kodi-aside', KodiAside);


### PR DESCRIPTION
- Actualizado `<kodi-aside>` para incluir un menú de navegación con botones ("Play", "Stop", "Menu").
- Añadidos estilos para el menú (botones azules, hover, padding, etc.).
- Pruebas: `npm start` muestra el sidebar con botones, header, y main sin errores.